### PR TITLE
Add quasar/cli to dev dependencies, force clean install

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ There could be a couple reasons for this. Before filing and issue with the core 
 
 This project is written in Vue with Quasar and uses npm as its package manager. I'm pretty sure it'd work with yarn as well.
 
-Clone the repository and install the [Quasar cli](https://quasar.dev/start/quasar-cli) with `npm install --location=global @quasar/cli`. After that, run `npm install`. The development server can then be started with `quasar dev`.
+Clone the repository and install the [Quasar cli](https://quasar.dev/start/quasar-cli) with `npm install @quasar/cli  --save-dev`. After that, run `npm clean-install`. The development server can then be started with `quasar dev`.
 
 ### Translations
 


### PR DESCRIPTION
When adding quasar/cli after having run install, it might not download the correct esbuild architecture. This PR instructs to move quasar/cli to dev dependencies and to force a clean install of the project afterwards.